### PR TITLE
Fix an api error when the mail Nickname contains spaces

### DIFF
--- a/ms365_accountcreator/api/account_creation.py
+++ b/ms365_accountcreator/api/account_creation.py
@@ -45,5 +45,6 @@ class AccountCreation(Resource):
         except NameFormatError:
             abort(400, gettext("Name format not supported"))
         except GraphApiError as err:
+            APP_LOGGER.error("GraphAPI error", err, request.get_json())
             abort(500, gettext("Upstream API error"))
             APP_LOGGER.error(err)

--- a/ms365_accountcreator/logic/graph_api/__init__.py
+++ b/ms365_accountcreator/logic/graph_api/__init__.py
@@ -110,6 +110,7 @@ class ApiAdapter:
         token = ''.join(c for c in token if unicodedata.combining(c) == 0)
         # remove any remaining non ascii characters
         token = token.encode('ascii', 'ignore').decode('ascii')
+        token = token.replace(' ', '')
         return token
 
     def internal_get_user_attrs(self, first_name: str, last_name: str, user_deduplicate_number: int, password: str) -> Tuple[str]:


### PR DESCRIPTION
This happens when people hav emultiple names.
Also log api errors to improve debugging.