### PR TITLE
Create DB tables if missing on import

### DIFF
--- a/ms365_accountcreator/db_models/__init__.py
+++ b/ms365_accountcreator/db_models/__init__.py
@@ -33,13 +33,15 @@ def create_db_function():
     APP_LOGGER.info('Database created.')
 
 
+from sqlalchemy import inspect
+
 with APP.app_context():
-    try:
-        registered_email_address.RegisteredEmailAddress.query.first()
-        APP_LOGGER.info('Database tables already exist.')
-    except Exception:
+    inspector = inspect(DB.engine)
+    if 'RegisteredEmailAddress' not in inspector.get_table_names():
         APP_LOGGER.info('Database tables not found, creating them now...')
         create_db_function()
+    else:
+        APP_LOGGER.info('Database tables already exist.')
 
 
 @APP.cli.command('drop_db')

--- a/ms365_accountcreator/db_models/__init__.py
+++ b/ms365_accountcreator/db_models/__init__.py
@@ -33,6 +33,15 @@ def create_db_function():
     APP_LOGGER.info('Database created.')
 
 
+with APP.app_context():
+    try:
+        registered_email_address.RegisteredEmailAddress.query.first()
+        APP_LOGGER.info('Database tables already exist.')
+    except Exception:
+        APP_LOGGER.info('Database tables not found, creating them now...')
+        create_db_function()
+
+
 @APP.cli.command('drop_db')
 def drop_db():
     """Drop all db tables."""


### PR DESCRIPTION
On module import, enter APP.app_context() and attempt RegisteredEmailAddress.query.first(); if the query succeeds log that tables exist, otherwise log and call create_db_function() to create the database tables. This ensures the database schema is initialized early (before CLI commands like drop_db) and provides informative logging about the action taken.